### PR TITLE
Add Korean docs and organize example data

### DIFF
--- a/DIRECTORY_STRUCTURE.md
+++ b/DIRECTORY_STRUCTURE.md
@@ -1,0 +1,25 @@
+# 디렉터리 구조
+
+```
+MCMI/
+├── cv10class.py              # 10폴드 분류 모듈
+├── entropy.py                # 엔트로피 계산
+├── joint_entropy.py          # 결합 엔트로피 계산
+├── mcmi.py                   # MCMI 특징 선택 알고리즘
+├── mutual_information.py     # 상호 정보량 계산
+├── Feature Selection Package.zip
+├── GBMCNA.mat                # 예제 데이터
+├── Lung_CNA.mat              # 예제 데이터
+├── example/
+│   ├── input/                # 예제 입력 파일
+│   │   ├── test.vcf          # Beagle로 보간된 VCF
+│   │   └── phenotype.tsv     # 형질 정보
+│   ├── output/               # 예제 결과
+│   │   └── results.txt       # 실행 후 생성되는 파일
+│   ├── run_example.py        # 예제 실행 스크립트
+│   └── README.md             # 예제 설명
+└── README.md
+```
+
+`example` 폴더에서 `run_example.py`를 실행하면 `output/results.txt`가 생성됩니다.
+

--- a/README.md
+++ b/README.md
@@ -1,75 +1,60 @@
-### GitHub Repository Introduction
+# MCMI 특징 선택 알고리즘
 
-# MCMI Feature Selection Algorithm
+이 저장소는 Maximum Conditional Mutual Information(MCMI) 방법을 이용한 특징 선택 코드를 제공합니다. MATLAB 버전과 Python 버전이 포함되어 있으며, 예제 데이터와 실행 스크립트도 제공합니다.
 
-Welcome to the repository for the MCMI (Maximum Conditional Mutual Information) Feature Selection Algorithm. This repository contains the MATLAB code and necessary files for implementing the MCMI-based feature selection method, designed for high-dimensional datasets. The repository includes code for calculating entropy, joint entropy, and mutual information, as well as sample datasets.
+## 시작하기
 
-## Getting Started
+### 필요 환경
+- 원본 구현을 위한 MATLAB
+- Python 3
+- `numpy`, `scikit-learn` 패키지
 
-To use the MCMI feature selection algorithm, follow the instructions below:
+### 주요 파일
+- `mcmi.m` : MATLAB 구현
+- `mcmi.py` : Python 구현
+- `Feature Selection Package` 디렉터리: MATLAB에서 필요한 함수 모음
+  - `load_fspackage.m`
+  - `Entropy.m` / `entropy.py`
+  - `JointEntropy.m` / `joint_entropy.py`
+  - `MutualInformation.m` / `mutual_information.py`
+- 샘플 데이터
+  - `GBMCNA.mat`
+  - `Lung_CNA.mat`
 
-### Prerequisites
+## 사용 방법
 
-- MATLAB installed on your system
-
-### Files and Directories
-
-- **mcmi.m**: The main script for the MCMI feature selection algorithm.
-- **Feature Selection Package**: A folder containing supplementary functions required for the algorithm.
-  - **load_fspackage.m**: Script to load the necessary feature selection package.
-  - **Entropy.m**: Function to calculate entropy.
-  - **JointEntropy.m**: Function to calculate joint entropy.
-  - **MutualInformation.m**: Function to calculate mutual information.
-- **Datasets**:
-  - **GBMCNA.mat**: Sample dataset for feature selection.
-  - **Lung_CNA.mat**: Another sample dataset for feature selection.
-
-### Usage Instructions
-
-1. **Clone the repository**:
+1. 저장소 클론
    ```bash
    git clone https://github.com/yourusername/mcmi-feature-selection.git
-   ```
-
-2. **Navigate to the repository directory**:
-   ```bash
    cd mcmi-feature-selection
    ```
-
-3. **Load the Feature Selection Package**:
-   Open MATLAB and run the following command to load the necessary package:
+2. MATLAB 패키지 로드
    ```matlab
    run('Feature Selection Package/load_fspackage.m')
    ```
+3. MCMI 실행
+   - MATLAB: `run('mcmi.m')`
+   - Python: `python mcmi.py`
 
-4. **Run the MCMI algorithm**:
-   Execute the `mcmi.m` script in MATLAB:
-   ```matlab
-   run('mcmi.m')
-   ```
+## 예제
 
-### Sample Datasets
+`example` 폴더에는 Beagle로 보간된 작은 VCF 파일과 형질 정보가 들어 있습니다. 아래와 같이 실행하면 선택된 feature 인덱스가 `output/results.txt`에 저장됩니다.
 
-- **GBMCNA.mat**: This dataset contains genomic data for feature selection.
-- **Lung_CNA.mat**: This dataset includes lung cancer-related genomic data for feature selection.
+```bash
+pip install numpy scikit-learn
+cd example
+python3 run_example.py
+```
 
-### Functions
+## 함수 설명
+- `entropy.py`: 엔트로피 계산
+- `joint_entropy.py`: 결합 엔트로피 계산
+- `mutual_information.py`: 상호 정보량 계산
 
-- **Entropy.m**: Function to compute the entropy of a variable.
-- **JointEntropy.m**: Function to compute the joint entropy of two variables.
-- **MutualInformation.m**: Function to compute the mutual information between two variables.
-
-### Additional Information
-
-For more details on the MCMI algorithm and its applications, please refer to the accompanying documentation and code comments within the scripts.
-
----
-
-We hope you find this repository helpful for your feature selection tasks. If you have any questions or encounter any issues, please feel free to open an issue or contact us via GitHub.
+추가 내용은 각 스크립트의 주석을 참고하세요.
 
 ---
 
-**Repository Maintainer**: [Hongtao Shi]  
-**Contact**: [sht@qau.edu.cn]  
+저장소 관리자: Hongtao Shi  
+문의: sht@qau.edu.cn
 
-Happy coding!

--- a/cv10class.py
+++ b/cv10class.py
@@ -1,0 +1,46 @@
+import numpy as np
+from sklearn.naive_bayes import GaussianNB
+from sklearn import svm
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.ensemble import RandomForestClassifier
+
+
+def cv10class(nexl: np.ndarray, indices: np.ndarray, param: dict) -> float:
+    """10-fold cross validation classification."""
+    M, N = nexl.shape
+    results = []
+    for i in range(1, 11):
+        test = indices == i
+        train = ~test
+        train_data = nexl[train, :N-1]
+        train_target = nexl[train, N-1]
+        test_data = nexl[test, :N-1]
+        test_target = nexl[test, N-1]
+
+        if param.get("type") == 1:
+            model = GaussianNB()
+        elif param.get("type") == 2:
+            model = svm.SVC(kernel="rbf", C=1, gamma=0.15)
+        elif param.get("type") == 3:
+            model = KNeighborsClassifier(n_neighbors=50)
+        elif param.get("type") == 4:
+            model = DecisionTreeClassifier()
+        elif param.get("type") == 5:
+            model = RandomForestClassifier(n_estimators=100)
+        else:
+            raise ValueError("Unsupported classifier type")
+
+        model.fit(train_data, train_target)
+        predict_label = model.predict(test_data)
+        accuracy = np.mean(predict_label == test_target)
+        results.append(accuracy)
+
+    return float(np.mean(results))
+
+
+if __name__ == "__main__":
+    rng = np.random.default_rng(0)
+    data = rng.integers(0, 5, size=(100, 6))
+    indices = np.repeat(np.arange(1, 11), 10)
+    print(cv10class(data, indices, {"type": 1}))

--- a/entropy.py
+++ b/entropy.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+
+def entropy(X: np.ndarray) -> np.ndarray:
+    """Compute entropy (in bits) for each column of X."""
+    X = np.asarray(X)
+    if X.ndim == 1:
+        X = X[:, np.newaxis]
+
+    n, m = X.shape
+    H = np.zeros(m)
+    for col in range(m):
+        column = X[:, col]
+        values, counts = np.unique(column, return_counts=True)
+        P = counts.astype(float) / counts.sum()
+        H[col] = -np.sum(P * np.log2(P + 1e-12))
+    return H
+
+
+if __name__ == "__main__":
+    # Simple test
+    rng = np.random.default_rng(0)
+    data = rng.integers(0, 4, size=(1000, 1))
+    print(entropy(data))

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,23 @@
+# 예제 사용 방법
+
+이 폴더에는 Python 버전의 MCMI 알고리즘을 실행해 볼 수 있는 작은 데이터와 스크립트가 들어 있습니다.
+
+## 파일 구성
+
+- `input/test.vcf` : Beagle로 보간된 예시 VCF 파일
+- `input/phenotype.tsv` : VCF와 일치하는 형질 정보
+- `run_example.py` : 데이터를 불러와 `mcmi`를 실행하는 스크립트
+- `output/results.txt` : 스크립트 실행 결과가 저장되는 파일
+
+## 실행 방법
+
+저장소 루트에서 Python 의존성 설치 후 스크립트를 실행합니다.
+
+```bash
+pip install numpy scikit-learn
+cd example
+python3 run_example.py
+```
+
+실행이 끝나면 선택된 feature 인덱스가 `output/results.txt`에 기록됩니다.
+

--- a/example/input/phenotype.tsv
+++ b/example/input/phenotype.tsv
@@ -1,0 +1,5 @@
+SampleID	Phenotype
+Sample1	1
+Sample2	0
+Sample3	1
+Sample4	0

--- a/example/input/test.vcf
+++ b/example/input/test.vcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.2
+##source=Beagle 5.4
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample1	Sample2	Sample3	Sample4
+1	1000	rs1	A	G	.	PASS	.	GT:DS	0/0:0.0	0/1:1.0	1/1:2.0	0/0:0.0
+1	2000	rs2	T	C	.	PASS	.	GT:DS	0/1:1.0	0/0:0.0	0/1:1.0	1/1:2.0
+1	3000	rs3	G	A	.	PASS	.	GT:DS	1/1:2.0	0/1:1.0	0/0:0.0	0/0:0.0

--- a/example/output/results.txt
+++ b/example/output/results.txt
@@ -1,0 +1,1 @@
+Selected feature indices: 1

--- a/example/run_example.py
+++ b/example/run_example.py
@@ -1,0 +1,51 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import numpy as np
+from mcmi import mcmi
+
+
+def load_vcf(path):
+    samples = []
+    genos = []
+    with open(path) as f:
+        for line in f:
+            if line.startswith('##'):
+                continue
+            if line.startswith('#CHROM'):
+                parts = line.strip().split('\t')
+                samples = parts[9:]
+            else:
+                parts = line.strip().split('\t')
+                row = []
+                for val in parts[9:]:
+                    ds = val.split(':')[1]
+                    row.append(float(ds))
+                genos.append(row)
+    X = np.array(genos).T
+    return samples, X
+
+
+def load_pheno(path):
+    names = []
+    values = []
+    with open(path) as f:
+        next(f)
+        for line in f:
+            name, val = line.strip().split('\t')
+            names.append(name)
+            values.append(float(val))
+    return names, np.array(values)
+
+
+if __name__ == '__main__':
+    sample_names, X = load_vcf(os.path.join('input', 'test.vcf'))
+    pheno_names, y = load_pheno(os.path.join('input', 'phenotype.tsv'))
+    order = [sample_names.index(n) for n in pheno_names]
+    X = X[order]
+    selected = mcmi(X, y, max_features=2)
+    os.makedirs('output', exist_ok=True)
+    with open(os.path.join('output', 'results.txt'), 'w') as f:
+        f.write('Selected feature indices: ' + ','.join(map(str, selected)) + '\n')
+    print('Selected features:', selected)
+    print('Results written to results.txt')

--- a/joint_entropy.py
+++ b/joint_entropy.py
@@ -1,0 +1,19 @@
+import numpy as np
+from entropy import entropy
+
+
+def joint_entropy(X: np.ndarray) -> float:
+    """Compute joint entropy (in bits) of the columns of X."""
+    X = np.asarray(X)
+    if X.ndim == 1:
+        X = X[:, np.newaxis]
+
+    _, counts = np.unique(X, axis=0, return_counts=True)
+    P = counts.astype(float) / counts.sum()
+    return -np.sum(P * np.log2(P + 1e-12))
+
+
+if __name__ == "__main__":
+    rng = np.random.default_rng(0)
+    a = rng.integers(0, 4, size=(1000, 2))
+    print(joint_entropy(a))

--- a/mcmi.py
+++ b/mcmi.py
@@ -1,0 +1,66 @@
+"""Python implementation of the MCMI feature selection algorithm."""
+import numpy as np
+from sklearn.preprocessing import KBinsDiscretizer
+from mutual_information import mutual_information
+
+
+def mcmi(X: np.ndarray, y: np.ndarray, max_features: int = 1000) -> np.ndarray:
+    """Select features using Maximum Conditional Mutual Information (MCMI)."""
+    X = np.asarray(X)
+    y = np.asarray(y).ravel()
+
+    X = np.nan_to_num(X)
+
+    if not np.issubdtype(X.dtype, np.integer):
+        disc = KBinsDiscretizer(n_bins=10, encode="ordinal", strategy="quantile")
+        X = disc.fit_transform(X)
+
+    newx = X
+    EnY = mutual_information(y.reshape(-1, 1), y.reshape(-1, 1))  # not used but kept
+    m, n = newx.shape
+
+    MI = np.array([mutual_information(newx[:, [i]], y) for i in range(n)])
+    ind = np.argsort(MI)[::-1]
+
+    rem = ind[:max_features].tolist()
+    opt = [rem.pop(0)]
+    conf = newx[:, opt]
+    mi_all = mutual_information(newx, y)
+
+    while rem:
+        mi_con = mutual_information(conf, y)
+        con_mi = []
+        for idx in rem:
+            new_f = np.column_stack([conf, newx[:, idx]])
+            mi_new = mutual_information(new_f, y)
+            con_mi.append(mi_new - mi_con)
+        con_mi = np.array(con_mi)
+        order = np.argsort(con_mi)[::-1]
+        if con_mi[order[0]] <= 0:
+            break
+        best_idx = rem[order[0]]
+        opt.append(best_idx)
+        conf = np.column_stack([conf, newx[:, best_idx]])
+        rem.pop(order[0])
+        zero_indices = np.where(con_mi == 0)[0]
+        for z in sorted(zero_indices, reverse=True):
+            if z < len(rem):
+                rem.pop(z)
+        if con_mi[order[0]] + mi_con >= mi_all:
+            break
+
+    for k in range(len(opt) - 1, -1, -1):
+        con_new_f = np.delete(conf, k, axis=1)
+        mi_con_new = mutual_information(con_new_f, y)
+        if np.isclose(mi_con_new, mi_all):
+            opt.pop(k)
+            conf = con_new_f
+
+    return np.array(opt)
+
+
+if __name__ == "__main__":
+    rng = np.random.default_rng(0)
+    X = rng.integers(0, 5, size=(200, 10))
+    y = rng.integers(0, 2, size=200)
+    print(mcmi(X, y))

--- a/mutual_information.py
+++ b/mutual_information.py
@@ -1,0 +1,24 @@
+import numpy as np
+from entropy import entropy
+from joint_entropy import joint_entropy
+
+
+def mutual_information(X: np.ndarray, Y: np.ndarray) -> float:
+    """Return the mutual information (in bits) of X and Y."""
+    X = np.asarray(X)
+    Y = np.asarray(Y)
+    if X.ndim == 1:
+        X = X[:, np.newaxis]
+    if Y.ndim == 1:
+        Y = Y[:, np.newaxis]
+    if X.shape[0] != Y.shape[0]:
+        raise ValueError("X and Y must have the same number of rows")
+
+    return joint_entropy(X) + entropy(Y)[0] - joint_entropy(np.hstack([X, Y]))
+
+
+if __name__ == "__main__":
+    rng = np.random.default_rng(0)
+    X = rng.integers(0, 4, size=(1000, 2))
+    Y = rng.integers(0, 3, size=(1000, 1))
+    print(mutual_information(X, Y))


### PR DESCRIPTION
## Summary
- translate README and directory guide to Korean
- move example data into input/output folders
- update example script to use new locations
- provide Korean README for example

## Testing
- `pip install numpy scikit-learn`
- `python3 entropy.py`
- `cd example && python3 run_example.py`

------
https://chatgpt.com/codex/tasks/task_e_683f7fe46e648324bfe8f34bc9af8de9